### PR TITLE
fix: update visitor name on event creation

### DIFF
--- a/src/controllers/events.cr
+++ b/src/controllers/events.cr
@@ -162,6 +162,7 @@ class Events < Application
             email = attendee.email.strip.downcase
 
             guest = if existing_guest = Guest.query.find({email: email})
+                      existing_guest.name = attendee.name if existing_guest.name != attendee.name
                       existing_guest
                     else
                       Guest.new({
@@ -181,7 +182,6 @@ class Events < Application
             if attendee_ext_data = attendee.extension_data
               guest.ext_data = attendee_ext_data
             end
-
             guest.save!
 
             # Create attendees


### PR DESCRIPTION
Updates the stored name of the visitor on the creation of an event if that visitor is already in the system