### PR TITLE
fix: syntax error in specs

### DIFF
--- a/spec/controllers/events_spec.cr
+++ b/spec/controllers/events_spec.cr
@@ -795,7 +795,7 @@ module EventsHelper
          "resource"        => false,
          "checked_in"      => false,
          "visit_expected"  => true,
-         "extension_data":    {
+         "extension_data"  => {
            "buzz" => "fuzz",
          },
         },

--- a/spec/controllers/events_spec.cr
+++ b/spec/controllers/events_spec.cr
@@ -785,7 +785,7 @@ module EventsHelper
          "resource"        => false,
          "checked_in"      => false,
          "visit_expected"  => true,
-         "extension_data":    {
+         "extension_data"  => {
            "fuzz" => "bizz",
          },
         },


### PR DESCRIPTION
Resolves error triggering spec failure when build against crystal nightly.
