### PR TITLE
perf: avoid unnecessary allocation

### DIFF
--- a/src/controllers/events.cr
+++ b/src/controllers/events.cr
@@ -46,16 +46,20 @@ class Events < Application
 
     # Grab any existing event metadata
     metadatas = {} of String => EventMetadata
-    metadata_ids = [] of String
-    ical_uids = [] of String
-    results.map { |(_calendar_id, system, event)|
+    # Set size hint to save reallocation of Array
+    metadata_ids = Array(String).new(initial_capacity: results.size)
+    ical_uids = Array(String).new(initial_capacity: results.size)
+
+    results.each do |(_calendar_id, system, event)|
       if system
         metadata_ids << event.id.not_nil!
         ical_uids << event.ical_uid.not_nil!
-        # TODO:: how to deal with recurring events in Office365 where ical_uid is also different for each recurrance
+
+        # TODO: Handle recurring O365 events with differing `ical_uid`
+        # Determine how to deal with recurring events in Office365 where the `ical_uid` is  different for each recurrance
         metadata_ids << event.recurring_event_id.not_nil! if event.recurring_event_id && event.recurring_event_id != event.id
       end
-    }
+    end
 
     metadata_ids.uniq!
 

--- a/src/models/booking.cr
+++ b/src/models/booking.cr
@@ -154,7 +154,7 @@ class Booking
   end
 
   scope :by_user_or_email do |user_id_value, user_email_value, include_booked_by|
-    # TODO:: interpolate these values properly
+    # TODO: Construct `user_or_email` query correctly
     booked_by = include_booked_by ? %( OR "booked_by_id" = '#{user_id_value}') : ""
     user_id_value = user_id_value.try &.gsub(/[\'\"\)\(\\\/\$\?\;\:\<\>\+\=\*\&\^\#\!\`\%\}\{\[\]]/, "")
     user_email_value = user_email_value.try &.gsub(/[\'\"\)\(\\\/\$\?\;\:\<\>\=\*\&\^\!\`\%\}\{\[\]]/, "")


### PR DESCRIPTION
**Description of the change**

Tiny perf catch regarding iteration.
- Sets a better guess for the initial capacity of two collections
- Avoids an unnecessary `map` with an `each`

**Benefits**

Small memory and speed boost.