### PR TITLE
feat(bookings): update booking validation

### DIFF
--- a/src/controllers/bookings.cr
+++ b/src/controllers/bookings.cr
@@ -398,6 +398,10 @@ class Bookings < Application
     clashing_bookings = check_all_clashing(booking).to_a
     render :conflict, json: clashing_bookings.first if clashing_bookings.size > 0
 
+    render :conflict, json: booking.errors.map(&.to_s) if booking.booking_end < Time.utc.to_unix
+
+    # booked for 8am on the 6th then you can check in anytime before that as long as it's the 6th and the resource is available
+
     if booking.checked_in
       booking.checked_in_at = Time.utc.to_unix
     else
@@ -441,7 +445,6 @@ class Bookings < Application
     query.each do |booking|
       new_query.where { checked_out_at > starting } if booking.checked_out_at_column.defined?
     end
-
     new_query.to_a
   end
 

--- a/src/controllers/bookings.cr
+++ b/src/controllers/bookings.cr
@@ -440,7 +440,13 @@ class Bookings < Application
         starting: starting, ending: ending, booking_type: booking_type, asset_id: asset_id
       )
     query = query.where { id != new_booking.id } if new_booking.id_column.defined?
-    query.to_a
+
+    new_query = query.dup
+    query.each do |booking|
+      new_query.where { checked_out_at > starting } if booking.checked_out_at_column.defined?
+    end
+
+    new_query.to_a
   end
 
   private def check_concurrent(new_booking)


### PR DESCRIPTION
**Description of the change**

- Considers `checked_out_at` as the true booking end time when creating new bookings, updating existing bookings and checking into bookings
- Allows early check in on the same day if no other booking fall between current time and end of booking
- Prevents check in & approval actions being performed on deleted bookings

**Benefits**

Aligns booking behaviour with real world logic

**Applicable issues**

Closes #165 
