### PR TITLE
feat(calendars): precise free/busy availability requests

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -47,11 +47,11 @@ shards:
 
   email:
     git: https://github.com/arcage/crystal-email.git
-    version: 0.6.4
+    version: 0.7.0
 
   faker:
     git: https://github.com/askn/faker.git
-    version: 0.7.0
+    version: 0.8.0
 
   future:
     git: https://github.com/crystal-community/future.cr.git
@@ -91,7 +91,7 @@ shards:
 
   office365:
     git: https://github.com/placeos/office365.git
-    version: 1.14.0
+    version: 1.15.0
 
   open_api:
     git: https://github.com/elbywan/open_api.cr.git
@@ -111,7 +111,7 @@ shards:
 
   place_calendar:
     git: https://github.com/placeos/calendar.git
-    version: 4.12.1
+    version: 4.12.3
 
   placeos:
     git: https://github.com/placeos/crystal-client.git
@@ -123,7 +123,7 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 7.0.0
+    version: 7.6.7
 
   promise:
     git: https://github.com/spider-gazelle/promise.git
@@ -139,7 +139,7 @@ shards:
 
   rethinkdb-orm:
     git: https://github.com/spider-gazelle/rethinkdb-orm.git
-    version: 6.0.1
+    version: 6.0.2
 
   retriable:
     git: https://github.com/sija/retriable.cr.git

--- a/spec/controllers/bookings_spec.cr
+++ b/spec/controllers/bookings_spec.cr
@@ -892,7 +892,7 @@ describe Bookings do
     booking.checked_out_at = 10.minutes.from_now.to_unix
     booking.save!
 
-    booking2 = BookingsHelper.create_booking(tenant.id, 15.minutes.from_now.to_unix, 25.minutes.from_now.to_unix, asset_id)
+    BookingsHelper.create_booking(tenant.id, 15.minutes.from_now.to_unix, 25.minutes.from_now.to_unix, asset_id)
 
     sleep 2
 

--- a/spec/controllers/calendars_spec.cr
+++ b/spec/controllers/calendars_spec.cr
@@ -59,6 +59,25 @@ describe Calendars do
     body = Context(Calendars, JSON::Any).response("GET", route, headers: Mock::Headers.office365_guest, &.free_busy)[1].as_a
     body.should eq(CalendarsHelper.free_busy_output)
   end
+
+  it "#free_busy should not allow an interval of less than 5 minutes" do
+    WebMock.stub(:get, "https://graph.microsoft.com/v1.0/users/dev@acaprojects.com/calendars?")
+      .to_return(body: File.read("./spec/fixtures/calendars/o365/show.json"))
+    WebMock.stub(:post, "#{ENV["PLACE_URI"]}/auth/oauth/token")
+      .to_return(body: File.read("./spec/fixtures/tokens/placeos_token.json"))
+    WebMock.stub(:get, "#{ENV["PLACE_URI"]}/api/engine/v2/systems?limit=1000&offset=0&zone_id=zone-EzcsmWbvUG6")
+      .to_return(body: File.read("./spec/fixtures/placeos/systems.json"))
+    WebMock.stub(:post, "https://graph.microsoft.com/v1.0/users/dev@acaprojects.com/calendar/getSchedule")
+      .to_return(body: File.read("./spec/fixtures/events/o365/get_schedule.json"))
+    WebMock.stub(:post, "https://login.microsoftonline.com/bb89674a-238b-4b7d-91ec-6bebad83553a/oauth2/v2.0/token")
+      .to_return(body: "")
+
+    now = Time.local.to_unix
+    later = (Time.local + Time::Span.new(minutes: 4)).to_unix
+    route = "#{CALENDARS_BASE}/free_busy?calendars=dev@acaprojects.com&period_start=#{now}&period_end=#{later}&zone_ids=zone-EzcsmWbvUG6"
+    bad_request = Context(Calendars, JSON::Any).response("GET", route, headers: Mock::Headers.office365_guest, &.free_busy)[0]
+    bad_request.should eq(400)
+  end
 end
 
 CALENDARS_BASE = Calendars.base_route

--- a/spec/controllers/guests_spec.cr
+++ b/spec/controllers/guests_spec.cr
@@ -269,7 +269,7 @@ describe Guests do
         "id": "sys_id-#{Random.rand(99)}"
     }))
 
-    WebMock.stub(:get, /^https:\/\/graph\.microsoft\.com\/v1\.0\/users\/.*\.com\/calendar\/calendarView\?startDateTime=2020-08-30T14:00:00-00:00&endDateTime=2020-08-31T13:59:59-00:00&%24filter=iCalUId\+eq\+%27040000008200E00074C5B7101A82E008000000008CD0441F4E7FD60100000000000000001000000087A54520ECE5BD4AA552D826F3718E7F%27&\$top=10000/)
+    WebMock.stub(:get, /^https:\/\/graph\.microsoft\.com\/v1\.0\/users\/[^\/]*\/calendar\/calendarView\?startDateTime=2020-08-30T14:00:00-00:00&endDateTime=2020-08-31T13:59:59-00:00.*/)
       .to_return(GuestsHelper.mock_event_query_json)
 
     tenant = get_tenant

--- a/src/controllers/bookings.cr
+++ b/src/controllers/bookings.cr
@@ -479,8 +479,8 @@ class Bookings < Application
 
   private def checked_out_clashes(query, booking, start_time)
     new_query = query.dup
-    query.each do |booking|
-      if booking.checked_out_at != nil
+    query.each do |query_booking|
+      if query_booking.checked_out_at != nil
         new_query = new_query.where { checked_out_at >= start_time }
       else
         new_query = new_query.where { booking_end >= start_time }

--- a/src/controllers/calendars.cr
+++ b/src/controllers/calendars.cr
@@ -63,7 +63,11 @@ class Calendars < Application
     # perform availability request
     period_start = Time.unix(query_params["period_start"].to_i64)
     period_end = Time.unix(query_params["period_end"].to_i64)
-    busy = client.get_availability(user.email, calendars, period_start, period_end)
+    duration = period_end - period_start
+
+    render :bad_request, json: "free/busy availability intervals must be greater than 5 minutes" if duration.total_minutes < 5
+    availability_view_interval = [duration, Time::Span.new(minutes: 30)].min.total_minutes.to_i!
+    busy = client.get_availability(user.email, calendars, period_start, period_end, view_interval: availability_view_interval)
 
     results = busy.map { |details|
       if system = candidates[details.calendar]?


### PR DESCRIPTION
**Description of the change**

`/free_busy` controller now calculates the duration between given times and if this value is greater than 5 minutes it will use this as the free/busy availability interval else it will return a `400` error

**Benefits**

- Allows bookings that are less than 30 minutes to be booked
- free/busy information is now more exact

**Applicable issues**

Closes https://github.com/PlaceOS/office365/issues/29