### PR TITLE
refactor: set app name to `staff-api`

### DIFF
--- a/src/constants.cr
+++ b/src/constants.cr
@@ -1,5 +1,5 @@
 module App
-  NAME    = "StaffAPI"
+  NAME    = "staff-api"
   VERSION = {{ `shards version "#{__DIR__}"`.chomp.stringify.downcase }}
 
   ENVIRONMENT = ENV["SG_ENV"]? || "development"


### PR DESCRIPTION
**Description of the change**

Aligns `APP_NAME` with other service's lowercased kebab cased names

**Benefits**

Consistency with other services