### PR TITLE
feat(bookings): adjust booking limit checks

### DIFF
--- a/spec/controllers/bookings_spec.cr
+++ b/spec/controllers/bookings_spec.cr
@@ -667,16 +667,22 @@ describe Bookings do
     end
   end
 
-  describe "booking_limits" do
-    # add support for configurable booking limits on resources
-    it "#create and #update should respect booking limits" do
+  describe "booking_limits", focus: true do
+    before_all do
       WebMock.stub(:post, "#{ENV["PLACE_URI"]}/auth/oauth/token")
         .to_return(body: File.read("./spec/fixtures/tokens/placeos_token.json"))
       WebMock.stub(:post, "#{ENV["PLACE_URI"]}/api/engine/v2/signal?channel=staff/booking/changed")
         .to_return(body: "")
       WebMock.stub(:post, "#{ENV["PLACE_URI"]}/api/engine/v2/signal?channel=staff/guest/attending")
         .to_return(body: "")
+    end
 
+    after_all do
+      WebMock.reset
+    end
+
+    # add support for configurable booking limits on resources
+    it "#create and #update should respect booking limits" do
       # Set booking limit
       tenant = get_tenant
       tenant.booking_limits = JSON.parse(%({"desk": 2}))
@@ -729,13 +735,6 @@ describe Bookings do
     end
 
     it "#create and #update should allow overriding booking limits" do
-      WebMock.stub(:post, "#{ENV["PLACE_URI"]}/auth/oauth/token")
-        .to_return(body: File.read("./spec/fixtures/tokens/placeos_token.json"))
-      WebMock.stub(:post, "#{ENV["PLACE_URI"]}/api/engine/v2/signal?channel=staff/booking/changed")
-        .to_return(body: "")
-      WebMock.stub(:post, "#{ENV["PLACE_URI"]}/api/engine/v2/signal?channel=staff/guest/attending")
-        .to_return(body: "")
-
       # Set booking limit
       tenant = get_tenant
       tenant.booking_limits = JSON.parse(%({"desk": 1}))
@@ -764,13 +763,6 @@ describe Bookings do
     end
 
     it "#update limit check can't clash with itself when updating a booking" do
-      WebMock.stub(:post, "#{ENV["PLACE_URI"]}/auth/oauth/token")
-        .to_return(body: File.read("./spec/fixtures/tokens/placeos_token.json"))
-      WebMock.stub(:post, "#{ENV["PLACE_URI"]}/api/engine/v2/signal?channel=staff/booking/changed")
-        .to_return(body: "")
-      WebMock.stub(:post, "#{ENV["PLACE_URI"]}/api/engine/v2/signal?channel=staff/guest/attending")
-        .to_return(body: "")
-
       # Set booking limit
       tenant = get_tenant
       tenant.booking_limits = JSON.parse(%({"desk": 2}))
@@ -799,13 +791,6 @@ describe Bookings do
     end
 
     it "#create and #update should respect booking limits when booking on behalf of other users" do
-      WebMock.stub(:post, "#{ENV["PLACE_URI"]}/auth/oauth/token")
-        .to_return(body: File.read("./spec/fixtures/tokens/placeos_token.json"))
-      WebMock.stub(:post, "#{ENV["PLACE_URI"]}/api/engine/v2/signal?channel=staff/booking/changed")
-        .to_return(body: "")
-      WebMock.stub(:post, "#{ENV["PLACE_URI"]}/api/engine/v2/signal?channel=staff/guest/attending")
-        .to_return(body: "")
-
       # Set booking limit
       tenant = get_tenant
       tenant.booking_limits = JSON.parse(%({"desk": 2}))

--- a/spec/controllers/bookings_spec.cr
+++ b/spec/controllers/bookings_spec.cr
@@ -668,7 +668,7 @@ describe Bookings do
   end
 
   describe "booking_limits", focus: true do
-    before_all do
+    before_each do
       WebMock.stub(:post, "#{ENV["PLACE_URI"]}/auth/oauth/token")
         .to_return(body: File.read("./spec/fixtures/tokens/placeos_token.json"))
       WebMock.stub(:post, "#{ENV["PLACE_URI"]}/api/engine/v2/signal?channel=staff/booking/changed")
@@ -679,7 +679,7 @@ describe Bookings do
       Timecop.scale(600) # 1 second == 10 minutes
     end
 
-    after_all do
+    after_each do
       WebMock.reset
     end
 

--- a/spec/controllers/bookings_spec.cr
+++ b/spec/controllers/bookings_spec.cr
@@ -853,6 +853,21 @@ describe Bookings do
           headers: Mock::Headers.office365_guest, &.update)
       end
     end
+
+    pending "booking limit is not checked on checkout" do
+    end
+
+    pending "booking limit is not checked on #destroy" do
+    end
+
+    pending "#check_in only checks limit if checked out" do
+    end
+
+    pending "#update does not check limit if the new start and end time is inside the existing range" do
+    end
+
+    pending "checked out bookins do not count towards the limit" do
+    end
   end
 
   it "#prevents a booking being saved with an end time before the start time" do

--- a/src/controllers/bookings.cr
+++ b/src/controllers/bookings.cr
@@ -235,7 +235,7 @@ class Bookings < Application
 
     # check concurrent bookings don't exceed booking limits
     limit_override = query_params["limit_override"]?
-    check_booking_limits(tenant, existing_booking, limit_override)
+    check_booking_limits(tenant, existing_booking, limit_override) if reset_state
 
     if existing_booking.valid?
       existing_attendees = existing_booking.attendees.try(&.map { |a| a.email }) || [] of String

--- a/src/controllers/bookings.cr
+++ b/src/controllers/bookings.cr
@@ -513,12 +513,12 @@ class Bookings < Application
   private def check_booking_limits(tenant, booking, limit_override = nil)
     # check concurrent bookings don't exceed booking limits
     if limit = limit_override
-      concurrent_bookings = check_concurrent(booking)
+      concurrent_bookings = check_concurrent(booking).reject { |b| b.current_state.checked_out? }
       raise Error::BookingLimit.new(limit.to_i, concurrent_bookings) if concurrent_bookings.size >= limit.to_i
     else
       if booking_limits = tenant.booking_limits.as_h?
         if limit = booking_limits[booking.booking_type]?
-          concurrent_bookings = check_concurrent(booking)
+          concurrent_bookings = check_concurrent(booking).reject { |b| b.current_state.checked_out? }
           raise Error::BookingLimit.new(limit.as_i, concurrent_bookings) if concurrent_bookings.size >= limit.as_i
         end
       end

--- a/src/controllers/bookings.cr
+++ b/src/controllers/bookings.cr
@@ -405,6 +405,10 @@ class Bookings < Application
     clashing_bookings = check_in_clashing(booking)
     render :conflict, json: clashing_bookings.first if clashing_bookings.size > 0
 
+    # check concurrent bookings don't exceed booking limits
+    limit_override = query_params["limit_override"]?
+    check_booking_limits(tenant, booking, limit_override) if booking.current_state.checked_out?
+
     if booking.checked_in
       booking.checked_in_at = Time.utc.to_unix
     else


### PR DESCRIPTION

- checkout, delete (don't check limit)
- check-in (check limit only if already checked out)
- patch (don't check limit unless start and end range is modified outside of the current range)
  - allow changes to start and end times if the range is within the bounds of the old range
- Checked out bookings should not be counted when determining if the user has hit the booking limit
