### PR TITLE
feat(survey): include deleted questions by default and include delete…

### DIFF
--- a/OPENAPI_DOC.yml
+++ b/OPENAPI_DOC.yml
@@ -10150,6 +10150,9 @@ components:
           items:
             type: string
           nullable: true
+        deleted:
+          type: boolean
+          nullable: true
     Tenant__Responder:
       type: object
       properties:

--- a/spec/controllers/surveys/questions_spec.cr
+++ b/spec/controllers/surveys/questions_spec.cr
@@ -53,14 +53,14 @@ describe Surveys::Questions, tags: ["survey"] do
       response_json.as_a.map(&.["id"]).should contain(questions[2].id)
     end
 
-    it "should not include soft-deleted question by default" do
+    it "should include soft-deleted question by default" do
       questions = SurveyHelper.create_questions
       questions.first.soft_delete
 
       response = client.get(QUESTIONS_BASE, headers: headers)
       response.status_code.should eq(200)
       response_json = JSON.parse(response.body)
-      response_json.as_a.map(&.["id"]).should_not contain(questions[0].id)
+      response_json.as_a.map(&.["id"]).should contain(questions[0].id)
       response_json.as_a.map(&.["id"]).should contain(questions[1].id)
       response_json.as_a.map(&.["id"]).should contain(questions[2].id)
     end

--- a/spec/controllers/surveys/questions_spec.cr
+++ b/spec/controllers/surveys/questions_spec.cr
@@ -95,7 +95,7 @@ describe Surveys::Questions, tags: ["survey"] do
       it "should create a new question" do
         questions = SurveyHelper.create_questions
         survey = SurveyHelper.create_survey(question_order: questions.map(&.id))
-        answers = SurveyHelper.create_answers(survey: survey, questions: questions)
+        _answers = SurveyHelper.create_answers(survey: survey, questions: questions)
 
         update = {title: "Updated Title"}.to_json
 
@@ -109,7 +109,7 @@ describe Surveys::Questions, tags: ["survey"] do
       it "should soft delete the question" do
         questions = SurveyHelper.create_questions
         survey = SurveyHelper.create_survey(question_order: questions.map(&.id))
-        answers = SurveyHelper.create_answers(survey: survey, questions: questions)
+        _answers = SurveyHelper.create_answers(survey: survey, questions: questions)
 
         update = {title: "Updated Title"}.to_json
 
@@ -149,7 +149,7 @@ describe Surveys::Questions, tags: ["survey"] do
       it "should soft delete the question" do
         questions = SurveyHelper.create_questions
         survey = SurveyHelper.create_survey(question_order: questions.map(&.id))
-        answers = SurveyHelper.create_answers(survey: survey, questions: questions)
+        _answers = SurveyHelper.create_answers(survey: survey, questions: questions)
 
         response = client.delete("#{QUESTIONS_BASE}/#{questions.first.id}", headers: headers)
         response.status_code.should eq(202)

--- a/spec/controllers/surveys_spec.cr
+++ b/spec/controllers/surveys_spec.cr
@@ -16,7 +16,7 @@ describe Surveys, tags: ["survey"] do
     end
 
     it "should return a list of surveys filtered by zone_id" do
-      survey1 = SurveyHelper.create_survey(zone_id: "1")
+      _survey1 = SurveyHelper.create_survey(zone_id: "1")
       survey2 = SurveyHelper.create_survey(zone_id: "2")
 
       response = client.get("#{SURVEY_BASE}?zone_id=2", headers: headers)
@@ -26,7 +26,7 @@ describe Surveys, tags: ["survey"] do
 
     it "should return a list of surveys filtered by building_id" do
       survey1 = SurveyHelper.create_survey(building_id: "1")
-      survey2 = SurveyHelper.create_survey(building_id: "2")
+      _survey2 = SurveyHelper.create_survey(building_id: "2")
 
       response = client.get("#{SURVEY_BASE}?building_id=1", headers: headers)
       response.status_code.should eq(200)

--- a/src/controllers/surveys/questions.cr
+++ b/src/controllers/surveys/questions.cr
@@ -31,7 +31,7 @@ class Surveys::Questions < Application
       question_ids = Survey.find!(survey_id).question_ids
       query = query.where { id.in?(question_ids) }
     end
-    query = deleted ? query.where { deleted_at != nil } : query.where { deleted_at == nil }
+    query = deleted ? query.where { deleted_at != nil } : query.where { deleted_at == nil } unless deleted.nil?
 
     query.to_a.map(&.as_json)
   end

--- a/src/models/survey/question.cr
+++ b/src/models/survey/question.cr
@@ -39,6 +39,7 @@ class Survey
       getter choices : JSON::Any? = nil
       getter max_rating : Int32? = nil
       getter tags : Array(String)? = nil
+      getter deleted : Bool? = nil
 
       def initialize(
         @id,
@@ -49,7 +50,8 @@ class Survey
         @required = nil,
         @choices = nil,
         @max_rating = nil,
-        @tags = nil
+        @tags = nil,
+        @deleted = nil
       )
       end
 
@@ -87,6 +89,7 @@ class Survey
         choices: self.choices,
         max_rating: self.max_rating_column.value(nil),
         tags: self.tags,
+        deleted: self.deleted_at_column.defined?
       )
     end
 


### PR DESCRIPTION
Makes `/surveys/questions` include deleted questions by default. They can be filtered out by setting `?deleted=false`

Includes a `deleted` field on the question model.