### PR TITLE
feat(events): patch metadata lookup using ical uid

### DIFF
--- a/OPENAPI_DOC.yml
+++ b/OPENAPI_DOC.yml
@@ -2554,6 +2554,14 @@ paths:
         schema:
           type: string
           nullable: true
+      - name: ical_uid
+        in: query
+        description: an alternative lookup for finding event-metadata
+        example: 5FC53010-1267-4F8E-BC28-1D7AE55A7C99
+        required: false
+        schema:
+          type: string
+          nullable: true
       responses:
         200:
           description: OK
@@ -2656,6 +2664,14 @@ paths:
         in: query
         description: the calendar associated with this event id
         example: user@org.com
+        required: false
+        schema:
+          type: string
+          nullable: true
+      - name: ical_uid
+        in: query
+        description: an alternative lookup for finding event-metadata
+        example: 5FC53010-1267-4F8E-BC28-1D7AE55A7C99
         required: false
         schema:
           type: string

--- a/shard.lock
+++ b/shard.lock
@@ -187,7 +187,7 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 9.0.1
+    version: 9.0.2
 
   pool:
     git: https://github.com/ysbaddaden/pool.git


### PR DESCRIPTION
so that office365 users can lookup metadata without making requests to get events. this is faster and works around issues related to delegated access to resources