### PR TITLE
fix(calendar): PPT-627 availability of timeslots imidiatly preceeding another meeting

### DIFF
--- a/src/controllers/calendars.cr
+++ b/src/controllers/calendars.cr
@@ -56,7 +56,9 @@ class Calendars < Application
 
     # perform availability request
     period_start = Time.unix(period_start)
-    period_end = Time.unix(period_end)
+    # removing 1 second from the end time to ensure the timeslot is showing up as available
+    # if there is a meeting starting imidiatly after the end of the period
+    period_end = Time.unix(period_end - 1)
     user_email = tenant.which_account(user.email)
     busy = client.get_availability(user_email, calendars, period_start, period_end)
 


### PR DESCRIPTION
Not entirely happy with this fix, but haven't found another option yet.
The issue is that the backend (Graph API) does not return the timeslot as available if a meeting starts at the same time as the checked end time. This results in it being impossible to book back-to-back meetings in concierge if the later meeting was booked before attempting to book the earlier one.