### PR TITLE
feat(staff): add links for fetching the users photo

### DIFF
--- a/src/controllers/staff.cr
+++ b/src/controllers/staff.cr
@@ -28,6 +28,12 @@ class Staff < Application
       end
       response.headers["Link"] = %(</api/staff/v1/people?#{params}>; rel="next")
     end
+
+    if client.client_id == :office365
+      users.map! do |user|
+        user.photo = "/api/staff/v1/people/#{user.email}/photo"
+      end
+    end
     users
   end
 
@@ -37,9 +43,30 @@ class Staff < Application
     @[AC::Param::Info(description: "a user id OR user email address", example: "user@org.com")]
     id : String,
   ) : PlaceCalendar::User
-    user = client.get_user_by_email(id)
+    if id.includes?('@')
+      user = client.get_user_by_email(id)
+    else
+      user = client.get_user(id)
+    end
     raise Error::NotFound.new("user #{id} not found") unless user
     user
+  end
+
+  # returns user photo
+  @[AC::Route::GET("/:id/photo")]
+  def photo(
+    @[AC::Param::Info(description: "a user id OR user email address", example: "user@org.com")]
+    id : String,
+  ) : PlaceCalendar::User
+    if client.client_id == :office365
+      # get token
+      # make request to the photo endpoint
+      # proxy the response
+    else
+      user = client.get_user_by_email(id)
+      raise Error::NotFound.new("user #{id} not found") unless user
+      
+    end
   end
 
   # returns the list of groups the user is a member


### PR DESCRIPTION
Google photo links don't require authentication.
GraphAPI photo links required authentication, so we need to:

1. add a photo link to the profile (which is a staff API link)
2. proxy the photo request through the backend so we don't leak the users graph api token

