### PR TITLE
chore(shard.lock): bump pg-orm to 2.2.3

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -135,7 +135,7 @@ shards:
 
   pg-orm:
     git: https://github.com/spider-gazelle/pg-orm.git
-    version: 2.2.2
+    version: 2.2.3
 
   place_calendar:
     git: https://github.com/placeos/calendar.git
@@ -151,7 +151,7 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 9.100.0
+    version: 9.100.1
 
   promise:
     git: https://github.com/spider-gazelle/promise.git


### PR DESCRIPTION
Pulls in the pg-orm fix that discards a connection whose COMMIT/ROLLBACK fails, instead of returning it to the pool poisoned. This resolves the "There is an existing transaction in this connection" 500s seen on PATCH /bookings/:id when a SERIALIZABLE serialization failure surfaces at commit and the wrap_in_transaction retry drew the poisoned connection.
