### PR TITLE
fix(deps): pg-orm 2.2.4 to stop the connection pool being poisoned (PPT-2642)

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -135,7 +135,7 @@ shards:
 
   pg-orm:
     git: https://github.com/spider-gazelle/pg-orm.git
-    version: 2.2.3
+    version: 2.2.4
 
   place_calendar:
     git: https://github.com/placeos/calendar.git


### PR DESCRIPTION
One line in `shard.lock`: pg-orm 2.2.3 → 2.2.4.

## What it fixes

A burst of concurrent `POST /bookings` left a connection stuck in an open transaction and back in the pool. Every write after that returned 500 with `There is an existing transaction in this connection` until the service restarted — and because reads kept working (they ran *inside* the orphaned transaction) the service looked healthy while being unable to book anything.

That error is a `DB::Error`, not a `PQ::PQError`, so `wrap_in_transaction`'s retry filter never caught it either.

## Cause

In pg-orm, not here. crystal-db's `TopLevelTransaction#commit` issues the `COMMIT` and only clears the connection's transaction flag afterwards in `do_close`, so a COMMIT that raises — exactly the serialization failures this controller retries — leaves the flag set for good. pg-orm's `release` rolled back only transactions it still had a record of, and its own `ensure` cleared that record first, so the single point where connections return to the pool was blind to it.

[spider-gazelle/pg-orm#19](https://github.com/spider-gazelle/pg-orm/pull/19) discards a connection that is still flagged rather than releasing it.

## Verification

Measured against *this service*, with images differing only by the pg-orm version, under the load that triggers it (12–16 concurrent `POST /bookings`):

| build | bursts stranding a connection | writable afterwards |
|---|---|---|
| control (pg-orm 2.2.3) | 3 of 4 | no — `{"500":3}` |
| pg-orm 2.2.4 | **0 of 11** | yes — `{"201":3}` |

The control was re-run in the same session afterwards to confirm the environment still reproduced rather than having gone quiet.

Connection reuse under normal sequential traffic is unchanged — backend PIDs are stable across bookings, with the same churn pattern as the control, so the new discard path is not firing when it should not.

Reproducer kept at `user-interfaces/e2e/support/repro/reg09-concurrent-bookings.ts`.

## Why it matters now

This is the last thing standing between the new workplace e2e suite and a clean nightly record — its concurrent booking specs are exactly what trips this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)